### PR TITLE
子コンポーネントのメソッドで親コンポーネントのプレイスホルダを書き換える

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,12 +5,12 @@
       <input
         class="main__input"
         v-model="todoName"
-        placeholder= "data1"
+        :placeholder="placeholder"
       />
       <button class="main__add" @click="addTodo">追加</button>
       <Todos :todos="todos"/>
     </div>
-    <Option :data1="placeholder" />
+    <Option />
     <Evaluation msg="Evaluation_file"/>
   </div>
 </template>
@@ -25,7 +25,8 @@ export default {
     return {
       todos: [],
       todoName: "",
-      data: "fff"
+      data: "fff",
+      placeholder: "デフォルト"
     }
   },
   components: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@
       <button class="main__add" @click="addTodo">追加</button>
       <Todos :todos="todos"/>
     </div>
-    <Option />
+    <Option @changePlaceholder="changePlaceholder" />
     <Evaluation msg="Evaluation_file"/>
   </div>
 </template>
@@ -42,6 +42,9 @@ export default {
         this.todoName = ""
       }
     },
+    changePlaceholder(value) {
+      this.placeholder = value
+    }
   }
 }
 </script>

--- a/src/components/Option.vue
+++ b/src/components/Option.vue
@@ -51,22 +51,21 @@ export default {
     defaultMode() {
       this.mode = "デフォルト"
       this.buttonMenu = false
-      this.$parent.placeholder = 'デフォルト';
+      this.$emit('changePlaceholder', "デフォルト")
     },
 
     // 煽りモードにするメソッド
     dissMode() {
       this.mode = "煽り"
       this.buttonMenu = false
-      this.data1 = "はよ仕事しろ"
-      this.$parent.placeholder = 'はよ仕事しろ';
+      this.$emit('changePlaceholder', "はよ仕事しろ")
     },
 
     // 筋トレモードにするメソッド
     muscleMode() {
       this.mode = "筋トレ"
       this.buttonMenu = false
-      this.$parent.placeholder = 'きんにく';
+      this.$emit('changePlaceholder', "きんにく")
     },
     
     // ハンバーガーメニューの中身を表示させるメソッド

--- a/src/components/Option.vue
+++ b/src/components/Option.vue
@@ -30,11 +30,7 @@
 
 export default {
   props: {
-    data1: {
-      type: String,
-      default: 'abc',
-      required: true
-    }
+
   },
   data() {
     return {
@@ -55,6 +51,7 @@ export default {
     defaultMode() {
       this.mode = "デフォルト"
       this.buttonMenu = false
+      this.$parent.placeholder = 'デフォルト';
     },
 
     // 煽りモードにするメソッド
@@ -62,12 +59,14 @@ export default {
       this.mode = "煽り"
       this.buttonMenu = false
       this.data1 = "はよ仕事しろ"
+      this.$parent.placeholder = 'はよ仕事しろ';
     },
 
     // 筋トレモードにするメソッド
     muscleMode() {
       this.mode = "筋トレ"
       this.buttonMenu = false
+      this.$parent.placeholder = 'きんにく';
     },
     
     // ハンバーガーメニューの中身を表示させるメソッド


### PR DESCRIPTION
## やりたいこと
Appコンポーネント内のプレースホルダーの値をOptionコンポーネント内のボタン（排他式選択肢風）で動的に変えたい。
Optionコンポーネントには「デフォルトモード」、「煽りモード」、「筋トレモード」という3つのボタンがある。
その中で例えば「筋トレモード」を押した場合はAppコンポーネント内のプレースホルダーの値が「筋トレしてください」と変更されるようにしたい。（いっせいくんの頭の中を翻訳）

## やったこと
以下の記事をみると、子コンポーネントから親コンポーネントの変数を書き換えることについて書いてあった。

https://www.webopixel.net/javascript/1224.html

~~このことを利用して今回は解決した。~~

```html
<script>
  export default { 
     created: function () {
      this.$parent.message = 'child!!!';
    }
  }
</script>
```

ただし、$parentを用いたやり方はあまり好ましくないらしい。
https://qiita.com/rhistoba/items/9e8521d7310ee9e3a226

ということで、emitを使ったものに変更。

1. 親コンポーネント内で自身の持つ変数の値を書き換えるメソッドを定義。
2. 子コンポーネントにv-onとして渡す
3. 子コンポーネントの任意の場所でemit